### PR TITLE
move all alpha-related operations to predict

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,15 +20,10 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] Test A
 - [ ] Test B
 
-**Test Configuration**:
-
-* OS version:
-* Python version:
-* MAPIE version:
-
 # Checklist:
 
 - [ ] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
+- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) files with a short description of my changes.
 - [ ] Linting passes successfully : `flake8 . --exclude=doc`
 - [ ] Typing passes successfully : `mypy mapie examples --strict --config-file mypy.ini`
 - [ ] Unit tests pass successfully : `pytest -vs --doctest-modules mapie`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 # Checklist:
 
 - [ ] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
-- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) files with a short description of my changes.
+- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
 - [ ] Linting passes successfully : `flake8 . --exclude=doc`
 - [ ] Typing passes successfully : `mypy mapie examples --strict --config-file mypy.ini`
 - [ ] Unit tests pass successfully : `pytest -vs --doctest-modules mapie`

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,5 +14,6 @@ Contributors
 * Nicolas Brunel <nbrunel@quantmetry.com>
 * Issam Ibnouhsein <iibnouhsein@quantmetry.com>
 * François Deheeger <francois.deheeger@michelin.com>
+* Rémi Adon <remi.adon@protonmail.com>
 
 To be continued ...

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,7 +64,7 @@ Updating changelog
 
 You can make your contribution visible by :
 
-1. adding your name to the Contributors sections of `CONTRIBUTING.rst <https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst>`_
+1. adding your name to the Contributors sections of `AUTHORS.rst <https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst>`_
 2. adding a line describing your change into `HISTORY.rst <https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst>`_
 
 Testing

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.1.4 (2021-04-30)
+------------------
+
+* Move all alpha related operations to predict
+
 0.1.3 (2021-04-30)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 ------------------
 
 * Move all alpha related operations to predict
+* Assume default LinearRegression if estimator is None
+* Improve documentation
 
 0.1.3 (2021-04-30)
 ------------------

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -9,6 +9,7 @@
     * `pytest -vs --doctest-modules mapie`
     * `pytest -vs --doctest-modules --cov-branch --cov=mapie --pyargs mapie`
 - [ ] Update the version number with `bump2version major|minor|patch`.
+- [ ] Push new tag to your commit: `git push --tags`
 - [ ] Build source distribution:
     * `rm -rf build dist`
     * `python setup.py sdist bdist_wheel`
@@ -22,5 +23,4 @@
     * `pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ mapie`
     * `conda activate`
     * `conda env remove -n test-mapie`
-- [ ] Add and push new tag to your commit: `git push --tags`
 - [ ] Create new release on GitHub for this tag, with all of the links.

--- a/examples/plot_barber2020_simulations.py
+++ b/examples/plot_barber2020_simulations.py
@@ -101,7 +101,7 @@ def PIs_vs_dimensions(
                     method=method,
                     n_splits=5,
                     shuffle=False,
-                    return_pred="ensemble"
+                    return_pred="median"
                 )
                 mapie.fit(X_train, y_train)
                 y_preds = mapie.predict(X_test)

--- a/examples/plot_barber2020_simulations.py
+++ b/examples/plot_barber2020_simulations.py
@@ -169,7 +169,7 @@ methods = [
     "cv_plus"
 ]
 alpha = 0.1
-ntrial = 1
+ntrial = 3
 dimensions = np.arange(10, 150, 10)
 results = PIs_vs_dimensions(methods, alpha, ntrial, dimensions)
 plot_simulation_results(results, title="Coverages and interval widths")

--- a/examples/plot_homoscedastic_1d_data.py
+++ b/examples/plot_homoscedastic_1d_data.py
@@ -137,7 +137,7 @@ for i, method in enumerate(methods):
         method=method,
         alpha=0.05,
         n_splits=10,
-        return_pred='ensemble'
+        return_pred='median'
     )
     mapie.fit(X_train.reshape(-1, 1), y_train)
     y_preds = mapie.predict(X_test.reshape(-1, 1))

--- a/examples/plot_nested-cv.py
+++ b/examples/plot_nested-cv.py
@@ -31,13 +31,10 @@ Forest Regressor as a base regressor for the CV+ method. For the sake of light
 computation, we adopt a RandomizedSearchCV parameter search strategy with a low
 number of iterations and with a reproducible random state.
 
-It is found that estimating prediction intervals via the CV+ method with the nested
-and non-nested approaches gives very similar scores and identical effective coverages.
-In practice, the nested cross-validated parameter search approach gives *out-of-fold*
-models which have slightly different best parameters.
-The two approaches therefore give slightly different predictions with the nested CV approach
+The two approaches give slightly different predictions with the nested CV approach
 estimating slightly larger prediction interval widths by a few percents at most (apart from a
 handful of exceptions).
+
 For this exemple, the two approaches result in identical scores and in identical effective
 coverages.
 

--- a/mapie/__init__.py
+++ b/mapie/__init__.py
@@ -1,3 +1,6 @@
+from . import estimators
+from . import metrics
+
 from ._version import __version__
 
-__all__ = ['__version__']
+__all__ = ["estimators", "metrics", "__version__"]

--- a/mapie/estimators.py
+++ b/mapie/estimators.py
@@ -32,7 +32,7 @@ def check_not_none(estimator: Optional[RegressorMixin]) -> None:
 class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
     """
     Estimator implementing the jackknife+ method and its variations
-    for estimating prediction intervals from leave-one-out regressors on
+    for estimating prediction intervals from leave-one-out or out-of-fold regressors on
     single-output data.
 
     Parameters
@@ -181,7 +181,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
 
     def fit(self, X: ArrayLike, y: ArrayLike) -> MapieRegressor:
         """
-        Fit all jackknife clones and rearrange them into a list.
+        Fit all estimator clones and rearrange them into a list.
         The initial estimator is fit apart.
 
         Parameters

--- a/mapie/estimators.py
+++ b/mapie/estimators.py
@@ -65,8 +65,11 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
 
     Attributes
     ----------
-    valid_methods_: List[str]
+    valid_methods: List[str]
         List of all valid methods.
+    
+    valid_return_preds: List[str]
+        List of all valid return_pred values..
 
     single_estimator_ : sklearn.RegressorMixin
         Estimator fit on the whole training set.
@@ -213,9 +216,9 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         Predict target on new samples with confidence intervals.
         Residuals from the training set and predictions from the model clones
         are central to the computation. Prediction Intervals for a given alpha are deduced from either
-        - quantiles of residuals (naive, jacknife, cv)
-        - quantiles of (predictions +/- residuals) (jacknife_plus, cv_plus)
-        - quantiles of (max/min(predictions) +/- residuals) (jackinfe_minmax, cv_minmax)
+        - quantiles of residuals (naive, jackknife, cv)
+        - quantiles of (predictions +/- residuals) (jackknife_plus, cv_plus)
+        - quantiles of (max/min(predictions) +/- residuals) (jackknife_minmax, cv_minmax)
 
         Parameters
         ----------

--- a/mapie/estimators.py
+++ b/mapie/estimators.py
@@ -67,7 +67,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
     ----------
     valid_methods: List[str]
         List of all valid methods.
-    
+
     valid_return_preds: List[str]
         List of all valid return_pred values..
 

--- a/mapie/tests/test_estimators.py
+++ b/mapie/tests/test_estimators.py
@@ -145,16 +145,6 @@ def test_invalid_method_in_predict(monkeypatch: Any, method: str) -> None:
         mapie.predict(X_boston)
 
 
-@pytest.mark.parametrize("return_pred", ["dummy"])
-def test_invalid_return_in_predict(monkeypatch: Any, return_pred: str) -> None:
-    """Test message in predict when invalid return_pred is selected."""
-    monkeypatch.setattr(MapieRegressor, "_check_parameters", lambda _: None)
-    mapie = MapieRegressor(DummyRegressor(), return_pred=return_pred)
-    mapie.fit(X_boston, y_boston)
-    with pytest.raises(ValueError, match=r".*Invalid return_pred.*"):
-        mapie.predict(X_boston)
-
-
 @pytest.mark.parametrize("method", all_methods)
 def test_fit_attribute(method: str) -> None:
     """Test class attributes shared by all PI methods."""
@@ -184,8 +174,8 @@ def test_cv_attributes(method: str) -> None:
 def test_none_estimator() -> None:
     """Test error raised when estimator is None."""
     mapie = MapieRegressor(None)
-    with pytest.raises(ValueError, match=r".*Invalid none estimator.*"):
-        mapie.fit(X_boston, y_boston)
+    mapie.fit(X_boston, y_boston)
+    assert isinstance(mapie.estimator, LinearRegression)
 
 
 def test_predinterv_outputshape() -> None:


### PR DESCRIPTION
# Description

- Move all `alpha`-related operation to `predict` method. Indeed, a user that want to play with several values of `alpha` does not want to refit every times `alpha` changes. This makes the `quantile_` attribute useless by the way.
- simplify `fit` methods by not restricting the computation of `k_` to cv methods (strictly speaking, `k_` is only used by `cv_plus` method by the way). This makes `fit` method shorter and easier to understand.
- Correct some inconsitency in `return_ypred` in the doc and in the code. "median" was sometimes used, but was not supposed to.
- add unit tests in order to detect when an invalid `return_y_pred` is used in the code
- add check in `check-parameters` about valid values of `return_y_pred`

## Type of change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] Linting passes successfully : `flake8 . --exclude=doc`
- [x] Typing passes successfully : `mypy mapie examples --strict --config-file mypy.ini`
- [x] Unit tests pass successfully : `pytest -vs --doctest-modules mapie`
- [x] Coverage is 100% : `pytest -vs --doctest-modules --cov-branch --cov=mapie --pyargs mapie`
- [x] Documentation builds successfully : `cd doc; make clean; make html`