### PR TITLE
Change return pred

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 * Move all alpha related operations to predict
 * Assume default LinearRegression if estimator is None
 * Improve documentation
+* `return_pred` argument is now `ensemble` boolean
 
 0.1.3 (2021-04-30)
 ------------------

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -107,7 +107,7 @@ in order to obtain a 95% confidence for our prediction intervals.
     predintervs = {}
     for method in allmethods:
         mapie = MapieRegressor(
-            polyn_model, alpha=0.05, method=method, n_splits=5, return_pred='single'
+            polyn_model, alpha=0.05, method=method, n_splits=5, ensemble=False
         )
         mapie.fit(X_train, y_train)
         predintervs[method] = mapie.predict(X_test)
@@ -318,7 +318,7 @@ methods.
     predintervs = {}
     for method in allmethods:
         mapie = MapieRegressor(
-            polyn_model, alpha=0.05, method=method, n_splits=5, return_pred='single'
+            polyn_model, alpha=0.05, method=method, n_splits=5, ensemble=False
         )
         mapie.fit(X_train, y_train)
         predintervs[method] = mapie.predict(X_test)
@@ -534,7 +534,7 @@ and compare their prediction interval.
     predintervs = {}
     for name, model in zip(model_names, models):
         mapie = MapieRegressor(
-            model, alpha=0.05, method='cv_plus', n_splits=5, return_pred='median'
+            model, alpha=0.05, method='cv_plus', n_splits=5, ensemble=True
         )
         mapie.fit(X_train, y_train)
         predintervs[name] = mapie.predict(X_test)

--- a/examples/plot_barber2020_simulations.py
+++ b/examples/plot_barber2020_simulations.py
@@ -101,7 +101,7 @@ def PIs_vs_dimensions(
                     method=method,
                     n_splits=5,
                     shuffle=False,
-                    return_pred="median"
+                    ensemble=True
                 )
                 mapie.fit(X_train, y_train)
                 y_preds = mapie.predict(X_test)

--- a/examples/plot_homoscedastic_1d_data.py
+++ b/examples/plot_homoscedastic_1d_data.py
@@ -137,7 +137,7 @@ for i, method in enumerate(methods):
         method=method,
         alpha=0.05,
         n_splits=10,
-        return_pred='median'
+        ensemble=True
     )
     mapie.fit(X_train.reshape(-1, 1), y_train)
     y_preds = mapie.predict(X_test.reshape(-1, 1))

--- a/examples/plot_nested-cv.py
+++ b/examples/plot_nested-cv.py
@@ -89,9 +89,9 @@ best_est = cv_obj.best_estimator_
 mapie_non_nested = MapieRegressor(
     best_est,
     alpha=alpha,
-    method='cv_plus',
+    method="cv_plus",
     n_splits=n_cv,
-    return_pred='median',
+    ensemble=True,
     random_state=random_state
 )
 mapie_non_nested.fit(X_train, y_train)
@@ -115,9 +115,9 @@ cv_obj = RandomizedSearchCV(
 mapie_nested = MapieRegressor(
     cv_obj,
     alpha=alpha,
-    method='cv_plus',
+    method="cv_plus",
     n_splits=n_cv,
-    return_pred='median',
+    ensemble=True,
     random_state=random_state
 )
 mapie_nested.fit(X_train, y_train)
@@ -145,7 +145,7 @@ ax1.set_ylabel("Prediction interval width using the non-nested CV approach")
 ax1.set_xlim([min_x, max_x])
 ax1.set_ylim([min_x, max_x])
 ax1.scatter(widths_nested, widths_non_nested)
-ax1.plot([min_x, max_x], [min_x, max_x], ls='--', color='k')
+ax1.plot([min_x, max_x], [min_x, max_x], ls="--", color="k")
 ax2.set_xlabel("[width(non-nested CV) - width(nested CV)] / width(non-nested CV)")
 ax2.set_ylabel("Counts")
 ax2.hist((widths_non_nested - widths_nested)/widths_non_nested, bins=15)

--- a/mapie/estimators.py
+++ b/mapie/estimators.py
@@ -49,18 +49,18 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
     n_splits: int, optional
         Number of splits for cross-validation, by default 5.
 
-    shuffle: bool, default=True
-        Whether to shuffle the data before splitting into batches.
+    shuffle: bool, optional
+        Whether to shuffle the data before splitting into batches, by default True.
 
-    ensemble: bool, default=False
+    ensemble: bool, optional
         Determines how to return the predictions.
         If False, returns the predictions from the single estimator trained on the full training dataset.
         If True, returns the median of the prediction intervals computed from the out-of-folds models.
 
-        By default `True`.
+        By default `False`.
 
     random_state : int, optional
-        Control randomness of cross-validation if relevant.
+        Control randomness of cross-validation if relevant, by default None.
 
     Attributes
     ----------

--- a/mapie/estimators.py
+++ b/mapie/estimators.py
@@ -52,13 +52,12 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
     shuffle: bool, default=True
         Whether to shuffle the data before splitting into batches.
 
-    return_pred: str, optional
-        Return the predictions from either
-        - the single estimator trained on the full training dataset ("single")
-        - the median of the prediction intervals computed from the leave-one-out or out-of-folds models ("median")
+    ensemble: bool, default=False
+        Determines how to return the predictions.
+        If False, returns the predictions from the single estimator trained on the full training dataset.
+        If True, returns the median of the prediction intervals computed from the out-of-folds models.
 
-        Valid for the jackknife_plus, jackknife_minmax, cv_plus, or cv_minmax methods.
-        By default "single".
+        By default `True`.
 
     random_state : int, optional
         Control randomness of cross-validation if relevant.
@@ -115,11 +114,6 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         "cv_minmax"
     ]
 
-    valid_return_preds = [
-        "single",
-        "median"
-    ]
-
     def __init__(
         self,
         estimator: Optional[RegressorMixin] = None,
@@ -127,7 +121,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         method: str = "cv_plus",
         n_splits: int = 5,
         shuffle: bool = True,
-        return_pred: str = "single",
+        ensemble: bool = False,
         random_state: Optional[int] = None
     ) -> None:
         self.estimator = estimator
@@ -135,7 +129,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         self.method = method
         self.n_splits = n_splits
         self.shuffle = shuffle
-        self.return_pred = return_pred
+        self.ensemble = ensemble
         self.random_state = random_state
 
     def _check_parameters(self) -> None:
@@ -146,8 +140,8 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
             raise ValueError("Invalid alpha. Please choose an alpha value between 0 and 1.")
         if self.method not in self.valid_methods:
             raise ValueError("Invalid method.")
-        if self.return_pred not in self.valid_return_preds:
-            raise ValueError("Invalid return_pred argument.")
+        if not isinstance(self.ensemble, bool):
+            raise ValueError("Invalid ensemble argument. Must be a boolean.")
         if self.estimator is None:
             self.estimator = LinearRegression()
 
@@ -241,7 +235,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
             y_pred_up = y_pred + quantile
         else:
             y_pred_multi = np.stack([e.predict(X) for e in self.estimators_], axis=1)
-            if self.return_pred == "median":
+            if self.ensemble:
                 y_pred = np.median(y_pred_multi, axis=1)
             if self.method == "cv_plus":
                 y_pred_multi = y_pred_multi[:, self.k_]

--- a/mapie/estimators.py
+++ b/mapie/estimators.py
@@ -56,6 +56,8 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         Determines how to return the predictions.
         If False, returns the predictions from the single estimator trained on the full training dataset.
         If True, returns the median of the prediction intervals computed from the out-of-folds models.
+        The Jackknife+ interval can be interpreted as an interval around the median prediction,
+        and is guaranteed to lie inside the interval, unlike the single estimator predictions.
 
         By default `False`.
 

--- a/mapie/tests/test_estimators.py
+++ b/mapie/tests/test_estimators.py
@@ -72,7 +72,7 @@ def test_optional_input_values() -> None:
     assert mapie.alpha == 0.1
     assert mapie.n_splits == 5
     assert mapie.shuffle
-    assert mapie.return_pred == "single"
+    assert mapie.ensemble is False
     assert mapie.random_state is None
 
 
@@ -117,11 +117,11 @@ def test_invalid_method_in_check_parameters(method: str) -> None:
         mapie.fit(X_boston, y_boston)
 
 
-@pytest.mark.parametrize("return_pred", ["dummy", "ensemble", "multi", "mean"])
-def test_invalid_return_pred_in_check_parameters(return_pred: str) -> None:
-    """Test error in check_parameters when invalid return_pred is selected."""
-    mapie = MapieRegressor(DummyRegressor(), return_pred=return_pred)
-    with pytest.raises(ValueError, match=r".*Invalid return_pred.*"):
+@pytest.mark.parametrize("ensemble", ["dummy", 1, 2., [1, 2]])
+def test_invalid_ensemble_in_check_parameters(ensemble: Any) -> None:
+    """Test error in check_parameters when invalid ensemble is selected."""
+    mapie = MapieRegressor(DummyRegressor(), ensemble=ensemble)
+    with pytest.raises(ValueError, match=r".*Invalid ensemble.*"):
         mapie.fit(X_boston, y_boston)
 
 
@@ -199,10 +199,10 @@ def test_results(method: str) -> None:
     assert_almost_equal(y_up, y_low, 10)
 
 
-@pytest.mark.parametrize("return_pred", ["single", "median"])
-def test_prediction_between_low_up(return_pred: str) -> None:
+@pytest.mark.parametrize("ensemble", [True, False])
+def test_prediction_between_low_up(ensemble: Any) -> None:
     """Test that prediction lies between low and up prediction intervals."""
-    mapie = MapieRegressor(LinearRegression(), return_pred=return_pred)
+    mapie = MapieRegressor(LinearRegression(), ensemble=ensemble)
     mapie.fit(X_boston, y_boston)
     y_preds = mapie.predict(X_boston)
     y_pred, y_low, y_up = y_preds[:, 0], y_preds[:, 1], y_preds[:, 2]

--- a/mapie/tests/test_estimators.py
+++ b/mapie/tests/test_estimators.py
@@ -200,7 +200,7 @@ def test_results(method: str) -> None:
 
 
 @pytest.mark.parametrize("ensemble", [True, False])
-def test_prediction_between_low_up(ensemble: Any) -> None:
+def test_prediction_between_low_up(ensemble: bool) -> None:
     """Test that prediction lies between low and up prediction intervals."""
     mapie = MapieRegressor(LinearRegression(), ensemble=ensemble)
     mapie.fit(X_boston, y_boston)


### PR DESCRIPTION
# Description

`return_pred` string argument is now a Boolean called `ensemble`. By default, `ensemble = False` returns the predictions from the unperturbed estimator.

## Type of change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `flake8 . --exclude=doc`
- [x] Typing passes successfully : `mypy mapie examples --strict --config-file mypy.ini`
- [x] Unit tests pass successfully : `pytest -vs --doctest-modules mapie`
- [x] Coverage is 100% : `pytest -vs --doctest-modules --cov-branch --cov=mapie --pyargs mapie`
- [x] Documentation builds successfully : `cd doc; make clean; make html`