### PR TITLE
Update Makefile to copy quickstart image in images/ folder

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -63,6 +63,7 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	cp _build/html/_images/sphx_glr_plot_toy_model_001.png images/quickstart_1.png
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -52,9 +52,6 @@ clean:
 	-rm -rf generated/*
 	-rm -rf modules/generated/*
 
-copyquickstartimage:
-	cp _build/html/_images/sphx_glr_plot_toy_model_001.png images/quickstart_1.png
-
 html:
 	# These two lines make the build a bit more lengthy, and the
 	# the embedding of images more robust

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -52,6 +52,9 @@ clean:
 	-rm -rf generated/*
 	-rm -rf modules/generated/*
 
+copyquickstartimage:
+	cp _build/html/_images/sphx_glr_plot_toy_model_001.png images/quickstart_1.png
+
 html:
 	# These two lines make the build a bit more lengthy, and the
 	# the embedding of images more robust


### PR DESCRIPTION
# Description

Update doc Makefile to copy image generated by `plot_toy_model.py` in `doc/images/` folder.

## Type of change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- Not relevant. I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- Not relevant. Linting passes successfully : `flake8 . --exclude=doc`
- Not relevant. Typing passes successfully : `mypy mapie examples --strict --config-file mypy.ini`
- Not relevant. Unit tests pass successfully : `pytest -vs --doctest-modules mapie`
- Not relevant. Coverage is 100% : `pytest -vs --doctest-modules --cov-branch --cov=mapie --pyargs mapie`
- [x] Documentation builds successfully : `cd doc; make clean; make html`