### PR TITLE
document and simplify parallelism

### DIFF
--- a/mapie/estimators.py
+++ b/mapie/estimators.py
@@ -265,10 +265,10 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         y : ArrayLike of shape (n_samples,)
             Input labels.
 
-        train_index : np.ndarray of shape (n_)
+        train_index : np.ndarray of shape (n_samples_train)
             Training data indices.
 
-        val_index : np.ndarray of shape (n_)
+        val_index : np.ndarray of shape (n_samples_val)
             Validation data indices.
 
         k : int

--- a/mapie/estimators.py
+++ b/mapie/estimators.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Union, Tuple
+from typing import Optional, Union, Tuple, List
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -314,7 +314,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         estimator = self._check_estimator(self.estimator)
         X, y = check_X_y(X, y, force_all_finite=False, dtype=["float64", "object"])
         y_pred = np.empty_like(y, dtype=float)
-        self.estimators_ = []
+        self.estimators_: List[RegressorMixin] = []
         self.n_features_in_ = X.shape[1]
         self.k_ = np.empty_like(y, dtype=int)
         self.single_estimator_ = clone(estimator).fit(X, y)
@@ -326,7 +326,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
                     clone(estimator), X, y, train_index, val_index, k
                 ) for k, (train_index, val_index) in enumerate(cv.split(X))
             )
-            self.estimators_, predictions, val_ids, val_indices  = map(list, zip(*cv_outputs))
+            self.estimators_, predictions, val_ids, val_indices = map(list, zip(*cv_outputs))
             predictions, val_ids, val_indices = map(np.concatenate, (predictions, val_ids, val_indices))
             self.k_[val_indices] = val_ids
             y_pred[val_indices] = predictions


### PR DESCRIPTION
# Description

- Complete documentation of `__fit_and_predict_oof_model`
- Reorder outputs of `__fit_and_predict_oof_model`
- rename some variables to increase readability
- simplify the postprocessing code after parallelism

## Type of change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Existing unit tests.

# Checklist:

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `flake8 . --exclude=doc`
- [x] Typing passes successfully : `mypy mapie examples --strict --config-file mypy.ini`
- [x] Unit tests pass successfully : `pytest -vs --doctest-modules mapie`
- [x] Coverage is 100% : `pytest -vs --doctest-modules --cov-branch --cov=mapie --pyargs mapie`
- [x] Documentation builds successfully : `cd doc; make clean; make html`