### PR TITLE
use pypa github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to PyPi
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:
@@ -13,14 +13,14 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.9'
-    - name: Install dependencies
+    - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN_VTA }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+    - name: Build package
+      run: python setup.py sdist bdist_wheel
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN_VTA }}

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,6 +1,7 @@
 # Release checklist
 
 - [ ] Update the version number with `bump2version major|minor|patch`
+- [ ] Push new tag to your commit: `git push --tags`
 - [ ] Edit HISTORY.rst and AUTHORS.rst to make sure it’s up-to-date and add release date
 - [ ] Check whether any new files need to go in MANIFEST.in
 - [ ] Make sure tests run, pass and cover 100% of the package:
@@ -18,7 +19,6 @@
     * `python setup.py sdist bdist_wheel`
 - [ ] Check that your package is ready for publication: `twine check dist/*`
 - [ ] Make sure everything is committed and pushed: `git push origin master`
-- [ ] Push new tag to your commit: `git push --tags`
 - [ ] Upload it to TestPyPi: `twine upload --repository-url https://test.pypi.org/legacy/ dist/*`
 - [ ] Test upload on TestPyPi:
     * `cd`


### PR DESCRIPTION
# Description

- reorder instructions in release checklist
- use pypa publish github  action for continuous deployment

## Type of change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `flake8 . --exclude=doc`
- [x] Typing passes successfully : `mypy mapie examples --strict`
- [x] Unit tests pass successfully : `pytest -vs --doctest-modules mapie`
- [x] Coverage is 100% : `pytest -vs --doctest-modules --cov-branch --cov=mapie --pyargs mapie`
- [x] Documentation builds successfully : `cd doc; make clean; make html`